### PR TITLE
Arrumado resposividade da seção "Onde Estamos?" e "participe"

### DIFF
--- a/css/localizacao.css
+++ b/css/localizacao.css
@@ -56,9 +56,6 @@ iframe{
     margin-top: 1rem
 }
 
-
-
-
 /*TABLET*/
 @media screen and (min-width:768px) {
     .localizacao{
@@ -94,8 +91,6 @@ iframe{
         font-family: 'Social-gothic';
         margin: 2rem 1rem 10rem 0;
         font-size: 1.5rem;
-        
-        
     }
     iframe{
         width: 90%;
@@ -109,7 +104,6 @@ iframe{
         margin-top: 1rem;
     }
 }
-
 
 /*NOTEBOOK*/
 @media screen and (min-width:1024px) {
@@ -128,22 +122,28 @@ iframe{
         font-family: 'Social-gothic';
         color: var(--yellow);
     }
-    .localizacao img{
+    .conteiner_img{
+        display: flex; 
+        justify-content: center; 
+        align-items: center; 
+        gap: 2rem; 
+        margin-top: 2rem; 
+        max-width: 100%;
+    }
+    .conteiner_img img{
         width: 25rem;
         border: 6px solid white;
         border-radius: 1rem;
-        margin-right: 30rem;
-       
+        margin: 0;
     }
     .infos{
         font-family: 'Social-gothic';
-        margin: -15rem 0 0 25rem;
+        margin: 0;
         font-size: 1.5rem;
-        
-        
+        justify-content: center;
     }
     .infos h3{
-        margin-left: 5rem;
+        margin: auto;
     }
     iframe{
         width: 90%;
@@ -153,8 +153,6 @@ iframe{
     }
     .infos p{
         font-family: 'Roboto';
-        margin-left: 25rem;
-        margin-top: 1rem
-        
+        margin: 2rem auto;
     }
 }

--- a/css/participe.css
+++ b/css/participe.css
@@ -1,7 +1,7 @@
 
 .container{
     text-align: center;
-    overflow: hidden;
+
 }
 .container h2{
     background-color: var(--dark_blue);
@@ -96,6 +96,7 @@
     .container{
         text-align: center;
         width: 100%;
+        overflow: hidden;
     }
     .container h2{
 

--- a/css/participe.css
+++ b/css/participe.css
@@ -1,6 +1,7 @@
 
 .container{
     text-align: center;
+    overflow: hidden;
 }
 .container h2{
     background-color: var(--dark_blue);

--- a/index.html
+++ b/index.html
@@ -302,13 +302,15 @@
             <h2>Onde Estamos?</h2>
             <p>Estamos localizado na <strong id="gothic_loc">Tecnológica Federal do Paraná - UTFPR</strong>
             </p>
-            <img src="./img/utfpr.jpeg" alt="UTFPR - IMG">
-            <div class="infos">
-                <h3>Campus Centro - Rua Sete de Setembro</h3>
-                <p >Bloco Q <br>
-                    Andar Térreo<br>
-                    Sala 12<br>
-                </p>
+            <div class="conteiner_img">
+                <img src="./img/utfpr.jpeg" alt="UTFPR - IMG">
+                <div class="infos">
+                    <h3>Campus Centro - Rua Sete de Setembro</h3>
+                    <p >Bloco Q <br>
+                        Andar Térreo<br>
+                        Sala 12<br>
+                    </p>
+            </div>
             </div>
             <iframe
                 src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3602.969743068633!2d-49.27139972492718!3d-25.439275077555873!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x94dce465f9b0c855%3A0xda22d429219f2f12!2sUniversidade%20Tecnol%C3%B3gica%20Federal%20do%20Paran%C3%A1%20%7C%20Curitiba%20Campus%20-%20Sede%20Centro!5e0!3m2!1sen!2sbr!4v1691672594904!5m2!1sen!2sbr"


### PR DESCRIPTION
Arrumado responsividade da seção "Onde Estamos?" por meio do display flexbox, adicionando a div de classe "conteiner_img" ao html para tal display, e adicionando eles ao centro da div com justify-content

Também coloquei na seção "participe" overflow: hidden no css para que a imagem vazada, em parte, não deixe o site maior, isto é, seja criada uma barra de rolagem para direita
 
